### PR TITLE
chore: bump helm chart version and update repo references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ This is ideal for:
 
 ```bash
 # Clone the repository
-git clone https://github.com/onyx-dot-app/code-interpreter.git
+git clone https://github.com/onyx-dot-app/python-sandbox.git
 cd code-interpreter
 
 # Activate a virtual environment

--- a/kubernetes/code-interpreter/Chart.yaml
+++ b/kubernetes/code-interpreter/Chart.yaml
@@ -2,16 +2,16 @@ apiVersion: v2
 name: code-interpreter
 description: A Helm chart for Code Interpreter - FastAPI service to execute Python code in isolated environments
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: latest
 keywords:
   - code-execution
   - python
   - fastapi
   - sandbox
-home: https://github.com/onyx-dot-app/code-interpreter
+home: https://github.com/onyx-dot-app/python-sandbox
 sources:
-  - https://github.com/onyx-dot-app/code-interpreter
+  - https://github.com/onyx-dot-app/python-sandbox
 maintainers:
   - name: Onyx
     email: hello@onyx.app

--- a/kubernetes/code-interpreter/README.md
+++ b/kubernetes/code-interpreter/README.md
@@ -14,7 +14,7 @@ This Helm chart deploys the Code Interpreter service on a Kubernetes cluster. Th
 ### Add the repository (if published)
 
 ```bash
-helm repo add code-interpreter https://onyx-dot-app.github.io/code-interpreter/
+helm repo add code-interpreter https://onyx-dot-app.github.io/python-sandbox/
 helm repo update
 ```
 


### PR DESCRIPTION
Update references after the repo rename from `code-interpreter` to `python-sandbox`.

- Bump Helm chart version to `0.2.1` (triggers chart-releaser to publish to GitHub Pages under the new repo name)
- Update `home` and `sources` URLs in `Chart.yaml`
- Update Helm repo URL in chart README
- Update git clone URL in CONTRIBUTING.md