### PR TITLE
fix: kubernetes exectutor health check uses out-of-scope command

### DIFF
--- a/code-interpreter/app/services/executor_kubernetes.py
+++ b/code-interpreter/app/services/executor_kubernetes.py
@@ -81,9 +81,30 @@ class KubernetesExecutor(BaseExecutor):
         self.service_account = KUBERNETES_EXECUTOR_SERVICE_ACCOUNT
 
     def check_health(self) -> HealthCheck:
-        """Verify Kubernetes API is reachable and the namespace is accessible."""
+        """Verify Kubernetes API is reachable and we can create pods in the namespace."""
         try:
-            self.v1.list_namespaced_pod(namespace=self.namespace, limit=1)
+            auth_api = client.AuthorizationV1Api()
+            review = auth_api.create_self_subject_access_review(
+                body=client.V1SelfSubjectAccessReview(
+                    spec=client.V1SelfSubjectAccessReviewSpec(
+                        resource_attributes=client.V1ResourceAttributes(
+                            namespace=self.namespace,
+                            verb="create",
+                            resource="pods",
+                        )
+                    )
+                )
+            )
+            if not review.status.allowed:
+                reason = review.status.reason or "no reason provided"
+                logger.warning(
+                    f"Health check failed: cannot create pods in namespace={self.namespace} "
+                    f"(reason={reason})"
+                )
+                return HealthCheck(
+                    status="error",
+                    message=f"Service account lacks permission to create pods in namespace={self.namespace}",
+                )
         except ApiException as e:
             return HealthCheck(
                 status="error",

--- a/code-interpreter/app/services/executor_kubernetes.py
+++ b/code-interpreter/app/services/executor_kubernetes.py
@@ -103,7 +103,10 @@ class KubernetesExecutor(BaseExecutor):
                 )
                 return HealthCheck(
                     status="error",
-                    message=f"Service account lacks permission to create pods in namespace={self.namespace}",
+                    message=(
+                        "Service account lacks permission to create "
+                        f"pods in namespace={self.namespace}"
+                    ),
                 )
         except ApiException as e:
             return HealthCheck(

--- a/code-interpreter/app/services/executor_kubernetes.py
+++ b/code-interpreter/app/services/executor_kubernetes.py
@@ -83,7 +83,7 @@ class KubernetesExecutor(BaseExecutor):
     def check_health(self) -> HealthCheck:
         """Verify Kubernetes API is reachable and the namespace is accessible."""
         try:
-            self.v1.read_namespace(name=self.namespace)
+            self.v1.list_namespaced_pod(namespace=self.namespace, limit=1)
         except ApiException as e:
             return HealthCheck(
                 status="error",


### PR DESCRIPTION
Currently the health check of the kubernetes executor uses read_namespace. This uses additional rbac permissions. We want to limit the amount of permissions. This change uses the create verb to check if we have access to that resource (which we need to create sub-pods).

```
*   Trying 127.0.0.1:8000...
* Connected to 127.0.0.1 (127.0.0.1) port 8000
> GET /health HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< date: Fri, 27 Feb 2026 18:49:40 GMT
< server: uvicorn
< content-length: 79
< content-type: application/json
< 
* Connection #0 to host 127.0.0.1 left intact
{"status":"error","message":"Kubernetes API error (namespace=onyx): Forbidden"}%    
```