### PR TITLE
feat(health): include service version in /health response

### DIFF
--- a/code-interpreter/app/main.py
+++ b/code-interpreter/app/main.py
@@ -4,7 +4,9 @@ import asyncio
 import logging
 import subprocess
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
+from contextlib import suppress
+from importlib.metadata import version as _package_version
 from shutil import which
 from typing import Final
 
@@ -24,6 +26,8 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+SERVICE_VERSION: Final[str] = _package_version("code-interpreter")
 
 
 def _ensure_docker_image_available() -> None:
@@ -123,7 +127,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 def create_app() -> FastAPI:
     app = FastAPI(
         title="Code Interpreter API",
-        version="0.1.0",
+        version=SERVICE_VERSION,
         docs_url="/docs",
         redoc_url="/redoc",
         openapi_url="/openapi.json",
@@ -134,7 +138,11 @@ def create_app() -> FastAPI:
     def health() -> HealthResponse:
         """Health check that verifies the executor backend is operational."""
         result = get_executor().check_health()
-        return HealthResponse(status=result.status, message=result.message)
+        return HealthResponse(
+            status=result.status,
+            message=result.message,
+            version=SERVICE_VERSION,
+        )
 
     app.include_router(api_router, prefix="/v1")
     return app

--- a/code-interpreter/app/main.py
+++ b/code-interpreter/app/main.py
@@ -4,8 +4,7 @@ import asyncio
 import logging
 import subprocess
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
 from importlib.metadata import version as _package_version
 from shutil import which
 from typing import Final

--- a/code-interpreter/app/models/schemas.py
+++ b/code-interpreter/app/models/schemas.py
@@ -120,6 +120,13 @@ class ListFilesResponse(BaseModel):
 class HealthResponse(BaseModel):
     status: Literal["ok", "error"]
     message: StrictStr | None = None
+    version: StrictStr = Field(
+        ...,
+        description=(
+            "Semver of the running service. Clients can compare against a "
+            "required minimum to detect whether new functionality is available."
+        ),
+    )
 
 
 DEFAULT_SESSION_TTL_SEC = 15 * 60

--- a/code-interpreter/pyproject.toml
+++ b/code-interpreter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-interpreter"
-version = "0.1.0"
+version = "0.3.3"
 description = "FastAPI service to execute Python code (sync, typed)"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/code-interpreter/tests/integration_tests/test_health.py
+++ b/code-interpreter/tests/integration_tests/test_health.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import create_app
+from app.main import SERVICE_VERSION, create_app
 from app.services.executor_base import HealthCheck
 from app.services.executor_docker import DockerExecutor
 from app.services.executor_factory import get_executor
@@ -29,6 +29,7 @@ def test_health_returns_ok_when_backend_healthy() -> None:
     body = response.json()
     assert body["status"] == "ok"
     assert body["message"] is None
+    assert body["version"] == SERVICE_VERSION
 
 
 def test_health_returns_error_when_backend_unhealthy() -> None:
@@ -42,6 +43,14 @@ def test_health_returns_error_when_backend_unhealthy() -> None:
     body = response.json()
     assert body["status"] == "error"
     assert body["message"] == "daemon down"
+    assert body["version"] == SERVICE_VERSION
+
+
+def test_health_version_matches_package_metadata() -> None:
+    """The version should come from the installed package, not be hardcoded."""
+    from importlib.metadata import version as package_version
+
+    assert package_version("code-interpreter") == SERVICE_VERSION
 
 
 def _make_completed(returncode: int, stderr: bytes = b"") -> subprocess.CompletedProcess[bytes]:

--- a/code-interpreter/tests/integration_tests/test_health.py
+++ b/code-interpreter/tests/integration_tests/test_health.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +13,8 @@ from app.main import SERVICE_VERSION, create_app
 from app.services.executor_base import HealthCheck
 from app.services.executor_docker import DockerExecutor
 from app.services.executor_factory import get_executor
+
+CHART_YAML = Path(__file__).resolve().parents[3] / "kubernetes" / "code-interpreter" / "Chart.yaml"
 
 
 @pytest.fixture(autouse=True)
@@ -51,6 +55,24 @@ def test_health_version_matches_package_metadata() -> None:
     from importlib.metadata import version as package_version
 
     assert package_version("code-interpreter") == SERVICE_VERSION
+
+
+def test_service_version_matches_helm_chart_version() -> None:
+    """Guard against drift between the Python package and the Helm chart.
+
+    A version mismatch means clients calling /health to gate on capabilities
+    would see one number while the deployment artifact reports another.
+    """
+    assert CHART_YAML.is_file(), f"Chart.yaml not found at {CHART_YAML}"
+    text = CHART_YAML.read_text(encoding="utf-8")
+    match = re.search(r"^version:\s*(\S+)\s*$", text, re.MULTILINE)
+    assert match is not None, f"could not find a top-level 'version:' line in {CHART_YAML}"
+    chart_version = match.group(1).strip("\"'")
+    assert chart_version == SERVICE_VERSION, (
+        f"Helm chart version {chart_version!r} != Python package version "
+        f"{SERVICE_VERSION!r}. Bump both together so /health and the deployed "
+        "chart report the same number."
+    )
 
 
 def _make_completed(returncode: int, stderr: bytes = b"") -> subprocess.CompletedProcess[bytes]:

--- a/code-interpreter/uv.lock
+++ b/code-interpreter/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "code-interpreter"
-version = "0.1.0"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "executor"
-version = "0.1.0"
+version = "0.3.3"
 description = "Dependency bundle for the code interpreter executor image"
 requires-python = ">=3.11,<3.12"
 license = { text = "MIT" }

--- a/executor/uv.lock
+++ b/executor/uv.lock
@@ -154,7 +154,7 @@ wheels = [
 
 [[package]]
 name = "executor"
-version = "0.1.0"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
Clients can now read ``version`` from the ``/health`` payload to gate calls to functionality that's only available in newer releases. The value is sourced from the installed package metadata rather than a hardcoded string, so the FastAPI app and the health response stay in sync with the version declared in pyproject.toml.