### PR TITLE
feat: Add fpdf2, pypdf and python-docx

### DIFF
--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11,<3.12"
 license = { text = "MIT" }
 authors = [{ name = "Chris Weaver" }]
 dependencies = [
+  "fpdf2>=2.8.1",
   "matplotlib==3.9.1",
   "matplotlib-inline>=0.1.7",
   "matplotlib-venn>=1.1.2",
@@ -19,6 +20,8 @@ dependencies = [
   "pandas==2.2.2",
   "pdfplumber>=0.11.7",
   "pydantic>=2.11.9",
+  "pypdf>=5.1.0",
+  "python-docx>=1.1.2",
   "python-pptx>=1.0.2",
   "scikit-image>=0.25.2",
   "scikit-learn>=1.7.2",

--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11,<3.12"
 license = { text = "MIT" }
 authors = [{ name = "Chris Weaver" }]
 dependencies = [
-  "fpdf2>=2.8.1",
+  "fpdf2==2.8.7",
   "matplotlib==3.9.1",
   "matplotlib-inline>=0.1.7",
   "matplotlib-venn>=1.1.2",
@@ -20,8 +20,8 @@ dependencies = [
   "pandas==2.2.2",
   "pdfplumber>=0.11.7",
   "pydantic>=2.11.9",
-  "pypdf>=5.1.0",
-  "python-docx>=1.1.2",
+  "pypdf==6.11.0",
+  "python-docx==1.2.0",
   "python-pptx>=1.0.2",
   "scikit-image>=0.25.2",
   "scikit-learn>=1.7.2",

--- a/executor/uv.lock
+++ b/executor/uv.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fpdf2", specifier = ">=2.8.1" },
+    { name = "fpdf2", specifier = "==2.8.7" },
     { name = "matplotlib", specifier = "==3.9.1" },
     { name = "matplotlib-inline", specifier = ">=0.1.7" },
     { name = "matplotlib-venn", specifier = ">=1.1.2" },
@@ -198,8 +198,8 @@ requires-dist = [
     { name = "pandas", specifier = "==2.2.2" },
     { name = "pdfplumber", specifier = ">=0.11.7" },
     { name = "pydantic", specifier = ">=2.11.9" },
-    { name = "pypdf", specifier = ">=5.1.0" },
-    { name = "python-docx", specifier = ">=1.1.2" },
+    { name = "pypdf", specifier = "==6.11.0" },
+    { name = "python-docx", specifier = "==1.2.0" },
     { name = "python-pptx", specifier = ">=1.0.2" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },

--- a/executor/uv.lock
+++ b/executor/uv.lock
@@ -144,6 +144,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -157,6 +166,7 @@ name = "executor"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fpdf2" },
     { name = "matplotlib" },
     { name = "matplotlib-inline" },
     { name = "matplotlib-venn" },
@@ -166,6 +176,8 @@ dependencies = [
     { name = "pandas" },
     { name = "pdfplumber" },
     { name = "pydantic" },
+    { name = "pypdf" },
+    { name = "python-docx" },
     { name = "python-pptx" },
     { name = "scikit-image" },
     { name = "scikit-learn" },
@@ -176,6 +188,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fpdf2", specifier = ">=2.8.1" },
     { name = "matplotlib", specifier = "==3.9.1" },
     { name = "matplotlib-inline", specifier = ">=0.1.7" },
     { name = "matplotlib-venn", specifier = ">=1.1.2" },
@@ -185,6 +198,8 @@ requires-dist = [
     { name = "pandas", specifier = "==2.2.2" },
     { name = "pdfplumber", specifier = ">=0.11.7" },
     { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pypdf", specifier = ">=5.1.0" },
+    { name = "python-docx", specifier = ">=1.1.2" },
     { name = "python-pptx", specifier = ">=1.0.2" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
@@ -208,6 +223,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/16/08db3917ee19e89d2eb0ee637d37cd4136c849dc421ff63f406b9165c1a1/fonttools-4.60.0-cp311-cp311-win32.whl", hash = "sha256:d493c175ddd0b88a5376e61163e3e6fde3be8b8987db9b092e0a84650709c9e7", size = 2229297, upload-time = "2025-09-17T11:32:24.834Z" },
     { url = "https://files.pythonhosted.org/packages/d2/0b/76764da82c0dfcea144861f568d9e83f4b921e84f2be617b451257bb25a7/fonttools-4.60.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc2770c9dc49c2d0366e9683f4d03beb46c98042d7ccc8ddbadf3459ecb051a7", size = 2277193, upload-time = "2025-09-17T11:32:27.094Z" },
     { url = "https://files.pythonhosted.org/packages/f9/a4/247d3e54eb5ed59e94e09866cfc4f9567e274fbf310ba390711851f63b3b/fonttools-4.60.0-py3-none-any.whl", hash = "sha256:496d26e4d14dcccdd6ada2e937e4d174d3138e3d73f5c9b6ec6eb2fd1dab4f66", size = 1142186, upload-time = "2025-09-17T11:33:59.287Z" },
+]
+
+[[package]]
+name = "fpdf2"
+version = "2.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/f2/72feae0b2827ed38013e4307b14f95bf0b3d124adfef4d38a7d57533f7be/fpdf2-2.8.7.tar.gz", hash = "sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9", size = 362351, upload-time = "2026-02-28T05:39:16.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/0a/cf50ecffa1e3747ed9380a3adfc829259f1f86b3fdbd9e505af789003141/fpdf2-2.8.7-py3-none-any.whl", hash = "sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19", size = 327056, upload-time = "2026-02-28T05:39:14.619Z" },
 ]
 
 [[package]]
@@ -561,6 +590,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/58/6dd97d78a4b17a7a6b9d1c6ad23895abc41f0fdc49c553cc05bdfdcc36d0/pypdf-6.11.0.tar.gz", hash = "sha256:062b51c81b0910e6d2755e99e1c5547a0a23b7d0a32322af66240d8edcfabe87", size = 6453975, upload-time = "2026-05-09T13:26:48.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/b1/68feb7eb3b99f0c020b414234825f4a5d70e0126c18d933770e8c93a35fc/pypdf-6.11.0-py3-none-any.whl", hash = "sha256:769394d5756d5b304c9b6bef88b54b1816b328e7e6fc9254e625529a15ed4ab8", size = 338819, upload-time = "2026-05-09T13:26:46.904Z" },
+]
+
+[[package]]
 name = "pypdfium2"
 version = "4.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +628,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a few more packages to allow the code interpreter service to have better pdf handling capabilities and docx handling capablities.

This was done in regards to a discord support ticket where the LLM struggled to perform these operations due to insufficient packages