### PR TITLE
Upgrade fastapi to 0.138.0 and starlette to 1.3.1

### DIFF
--- a/code-interpreter/app/api/routes.py
+++ b/code-interpreter/app/api/routes.py
@@ -52,7 +52,7 @@ def _validate_timeout(req: ExecuteRequest) -> None:
     settings = get_settings()
     if req.timeout_ms > settings.max_exec_timeout_ms:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"timeout_ms exceeds maximum of {settings.max_exec_timeout_ms} ms",
         )
 
@@ -130,7 +130,7 @@ def execute(req: ExecuteRequest) -> ExecuteResponse:
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         ) from exc
 
@@ -202,7 +202,7 @@ async def upload_file(file: UploadFile = File(...)) -> UploadFileResponse:  # no
     max_size_bytes = settings.max_file_size_mb * 1024 * 1024
     if len(content) > max_size_bytes:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"File size exceeds maximum of {settings.max_file_size_mb} MB",
         )
 
@@ -301,7 +301,7 @@ def create_session(req: CreateSessionRequest) -> CreateSessionResponse:
         ) from exc
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         ) from exc
 
@@ -345,7 +345,7 @@ def session_exec_bash(session_id: str, req: BashExecRequest) -> BashExecResponse
     settings = get_settings()
     if req.timeout_ms > settings.max_exec_timeout_ms:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"timeout_ms exceeds maximum of {settings.max_exec_timeout_ms} ms",
         )
 

--- a/code-interpreter/pyproject.toml
+++ b/code-interpreter/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11,<3.12"
 license = { text = "Proprietary" }
 authors = [{ name = "Your Team" }]
 dependencies = [
-  "fastapi==0.115.0",
+  "fastapi==0.138.0",
   "httpx>=0.28.1",
   "python-multipart>=0.0.31",
   "uvicorn==0.30.6",

--- a/code-interpreter/uv.lock
+++ b/code-interpreter/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = "==3.11.*"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -121,7 +130,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = "==0.115.0" },
+    { name = "fastapi", specifier = "==0.138.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "kubernetes", specifier = ">=31.0.0" },
     { name = "python-json-logger", specifier = ">=3.1.0" },
@@ -179,16 +188,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.0"
+version = "0.138.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/5e/bf0471f14bf6ebfbee8208148a3396d1a23298531a6cc10776c59f4c0f87/fastapi-0.115.0.tar.gz", hash = "sha256:f93b4ca3529a8ebc6fc3fcf710e5efa8de3df9b41570958abf1d97d843138004", size = 302295, upload-time = "2024-09-17T19:18:12.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/ab/a1f7eed031aeb1c406a6e9d45ca04bff401c8a25a30dd0e4fd2caae767c3/fastapi-0.115.0-py3-none-any.whl", hash = "sha256:17ea427674467486e997206a5ab25760f6b09e069f099b96f5b55a32fb6f1631", size = 94625, upload-time = "2024-09-17T19:18:10.962Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
 ]
 
 [[package]]
@@ -645,14 +656,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.38.6"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/b4/e25c3b688ef703d85e55017c6edd0cbf38e5770ab748234363d54ff0251a/starlette-0.38.6.tar.gz", hash = "sha256:863a1588f5574e70a821dadefb41e4881ea451a47a3cd1b4df359d4ffefe5ead", size = 2569491, upload-time = "2024-09-22T17:01:45.422Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/9c/93f7bc03ff03199074e81974cc148908ead60dcf189f68ba1761a0ee35cf/starlette-0.38.6-py3-none-any.whl", hash = "sha256:4517a1409e2e73ee4951214ba012052b9e16f60e90d73cfb06192c19203bbb05", size = 71451, upload-time = "2024-09-22T17:01:43.076Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -666,14 +678,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Upgrades the `code-interpreter` service to the latest FastAPI and Starlette:

| Package | Before | After |
| --- | --- | --- |
| fastapi | 0.115.0 | **0.138.0** |
| starlette (transitive) | 0.38.6 | **1.3.1** |

`fastapi==0.138.0` requires `starlette>=0.46.0` and `pydantic>=2.9.0`; the locked `pydantic` (2.11.9) already satisfies that. The lock also picks up a new transitive dep (`annotated-doc`) and a `typing-inspection` bump that fastapi 0.138 pulls in.

## Compatibility with existing usage

The API surface we use is all stable across these versions: `FastAPI` (with `lifespan`), `APIRouter`, `File`, `UploadFile`, `HTTPException`, `status`, `Response`, `StreamingResponse`, and `TestClient`.

Starlette 1.x deprecated two status-code constants we reference directly. They still work (same numeric values), but the upgrade started emitting `StarletteDeprecationWarning`s for them, so this PR migrates to the new names to keep things forward-compatible and warning-free:

- `HTTP_422_UNPROCESSABLE_ENTITY` → `HTTP_422_UNPROCESSABLE_CONTENT` (still 422)
- `HTTP_413_REQUEST_ENTITY_TOO_LARGE` → `HTTP_413_CONTENT_TOO_LARGE` (still 413)

No test asserts on these constant names (tests compare numeric status codes), so behavior is unchanged.

## Verification

- `mypy .` (strict) — pass
- `ruff check .` / `ruff format --check` — pass
- `pytest tests/integration_tests` — **149 passed**
- App construction + OpenAPI schema generation smoke test — pass (all 8 routes intact)

One pre-existing integration test, `test_data_stack::test_numpy_pandas_matplotlib_stack`, fails locally with exit code 137 (the executed data-science workload is SIGKILLed). It **fails identically on the pre-upgrade baseline**, so it is environmental and unrelated to this change.

### Known remaining warning
A single library-level warning remains from fastapi's own `testclient.py`: `Using \`httpx\` with \`starlette.testclient\` is deprecated; install \`httpx2\` instead.` It is internal to fastapi/starlette, test-only, and not controllable from our code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)