### PR TITLE
Release code-interpreter 0.4.4

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -27,6 +27,10 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Read version from pyproject
+        id: version
+        run: echo "version=$(grep -m1 '^version = ' executor/pyproject.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -34,6 +38,7 @@ jobs:
           images: ${{ env.DOCKERHUB_USERNAME }}/python-executor-sci
           tags: |
             type=semver,pattern={{version}}
+            type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
       - name: Build and push executor image
@@ -66,6 +71,10 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Read version from pyproject
+        id: version
+        run: echo "version=$(grep -m1 '^version = ' code-interpreter/pyproject.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -73,6 +82,7 @@ jobs:
           images: ${{ env.DOCKERHUB_USERNAME }}/code-interpreter
           tags: |
             type=semver,pattern={{version}}
+            type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
       - name: Build and push code-interpreter image

--- a/code-interpreter/pyproject.toml
+++ b/code-interpreter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-interpreter"
-version = "0.4.3"
+version = "0.4.4"
 description = "FastAPI service to execute Python code (sync, typed)"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/code-interpreter/uv.lock
+++ b/code-interpreter/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "code-interpreter"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "executor"
-version = "0.4.3"
+version = "0.4.4"
 description = "Dependency bundle for the code interpreter executor image"
 requires-python = ">=3.11,<3.12"
 license = { text = "MIT" }

--- a/executor/uv.lock
+++ b/executor/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "executor"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "fpdf2" },

--- a/kubernetes/code-interpreter/Chart.yaml
+++ b/kubernetes/code-interpreter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: code-interpreter
 description: A Helm chart for Code Interpreter - FastAPI service to execute Python code in isolated environments
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: latest
 keywords:
   - code-execution


### PR DESCRIPTION
## What

Bumps `code-interpreter` and `executor` from `0.4.3` → `0.4.4` and updates the publish workflow to emit a **versioned** image tag.

### Version bump
- `code-interpreter/pyproject.toml` + `executor/pyproject.toml`: `0.4.3` → `0.4.4`
- `uv.lock` refreshed for both (version-only change)

Changes included in 0.4.4 since the `0.4.3` tag:
- Upgrade FastAPI to 0.138.0 / Starlette to 1.3.1 (#60)
- Make executor Docker network configurable via `PYTHON_EXECUTOR_DOCKER_NETWORK` (#51)
- Dependency bumps (requests, virtualenv, idna, urllib3, pillow, lxml, pypdf, cryptography, etc.)

### Publish versioned tags
`docker-build-push.yml` historically only published `:latest`, because the build runs via `workflow_dispatch` on `main` where `type=semver` resolves to nothing. This adds a step that reads `version` from `pyproject.toml` and emits it via `type=raw`, so each build now pushes both `onyxdotapp/code-interpreter:<version>` / `onyxdotapp/python-executor-sci:<version>` **and** `:latest`. The existing `type=semver` line is kept so the `v*` tag path still works.

## Release steps (manual, after merge)
1. Merge this PR to `main`.
2. Tag + GitHub release `code-interpreter-0.4.4`.
3. Run **Build and Push Docker Images** (`workflow_dispatch`) on `main` → publishes `:0.4.4` + `:latest` for both images.

Once `:0.4.4` is published, the companion Onyx PR pins the deployment to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)