### PR TITLE
Add reportlab and svglib PDF-generation libraries

### DIFF
--- a/code-interpreter/pyproject.toml
+++ b/code-interpreter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-interpreter"
-version = "0.4.4"
+version = "0.4.5"
 description = "FastAPI service to execute Python code (sync, typed)"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/code-interpreter/uv.lock
+++ b/code-interpreter/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "code-interpreter"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "executor"
-version = "0.4.4"
+version = "0.4.5"
 description = "Dependency bundle for the code interpreter executor image"
 requires-python = ">=3.11,<3.12"
 license = { text = "MIT" }
@@ -23,10 +23,12 @@ dependencies = [
   "pypdf==6.13.3",
   "python-docx==1.2.0",
   "python-pptx>=1.0.2",
+  "reportlab>=5.0.0",
   "scikit-image>=0.25.2",
   "scikit-learn>=1.7.2",
   "scipy>=1.16.2",
   "seaborn>=0.13.2",
+  "svglib>=2.0.2",
   "xgboost>=3.0.5",
 ]
 

--- a/executor/uv.lock
+++ b/executor/uv.lock
@@ -133,6 +133,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -161,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "executor"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "fpdf2" },
@@ -177,10 +190,12 @@ dependencies = [
     { name = "pypdf" },
     { name = "python-docx" },
     { name = "python-pptx" },
+    { name = "reportlab" },
     { name = "scikit-image" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "seaborn" },
+    { name = "svglib" },
     { name = "xgboost" },
 ]
 
@@ -199,10 +214,12 @@ requires-dist = [
     { name = "pypdf", specifier = "==6.13.3" },
     { name = "python-docx", specifier = "==1.2.0" },
     { name = "python-pptx", specifier = ">=1.0.2" },
+    { name = "reportlab", specifier = ">=5.0.0" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.7.2" },
     { name = "scipy", specifier = ">=1.16.2" },
     { name = "seaborn", specifier = ">=0.13.2" },
+    { name = "svglib", specifier = ">=2.0.2" },
     { name = "xgboost", specifier = ">=3.0.5" },
 ]
 
@@ -666,6 +683,19 @@ wheels = [
 ]
 
 [[package]]
+name = "reportlab"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/d6/4b7b0cf56880eb96533e607967be6a939e344675601e033d113a0bfa1f4e/reportlab-5.0.0.tar.gz", hash = "sha256:e4494a0c6623ae213bb856fba523171b2b54a7bf629fda02d5e525a7b899a784", size = 3701928, upload-time = "2026-06-18T11:34:31.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/07/70085c17a369605f15e301d10ab902115019b1126c7253d964afc230c7d6/reportlab-5.0.0-py3-none-any.whl", hash = "sha256:9d5a3affa84919e1111ede580031266a570e93b1ce388219621347965ff1d93c", size = 1956710, upload-time = "2026-06-18T11:34:29.07Z" },
+]
+
+[[package]]
 name = "scikit-image"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -752,6 +782,22 @@ wheels = [
 ]
 
 [[package]]
+name = "svglib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cssselect2" },
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "reportlab" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/1f/e9dc8f16a834b6b0d5d7c0c20faeca614bcb31cbe67c54f61e3258978289/svglib-2.0.2.tar.gz", hash = "sha256:455e473dbe7066eea55c39de8194a6a3b646b6c37a255700257fd32115ddb218", size = 1341040, upload-time = "2026-06-18T07:12:50.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/de/eb6e07fb9fedba56921f8aa1dde4f5763b7abef1f962e6fea56a99092118/svglib-2.0.2-py3-none-any.whl", hash = "sha256:0fd04f1eb593802060427d6a59ab5127d65db6b8f5750d572f7df25097e36503", size = 45730, upload-time = "2026-06-18T07:12:49.221Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -770,6 +816,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/1d/99d2eb1d50f0832d6e6e057f7d3239b77210d663a048780b029d10324b14/tifffile-2025.9.20.tar.gz", hash = "sha256:a0fed4c613ff728979cb6abfd40832b6f36dc9da8183e52840418a25a00552eb", size = 368988, upload-time = "2025-09-20T17:24:43.498Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/15/e38bf2234e8c09fccc6ec53a7a4374e38a86f7a9d8394fb9c06e1a0f25a5/tifffile-2025.9.20-py3-none-any.whl", hash = "sha256:549dda2f2c65cc63b3d946942b9b43c09ae50caaae0aa7ea3d91a915acd45444", size = 230101, upload-time = "2025-09-20T17:24:41.831Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]
@@ -809,6 +867,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]

--- a/kubernetes/code-interpreter/Chart.yaml
+++ b/kubernetes/code-interpreter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: code-interpreter
 description: A Helm chart for Code Interpreter - FastAPI service to execute Python code in isolated environments
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: latest
 keywords:
   - code-execution


### PR DESCRIPTION
## What

Adds two PDF-generation libraries to the `executor` dependency bundle:

| Library | Version | License | Footprint |
|---|---|---|---|
| **reportlab** | `>=5.0.0` | BSD | **+1 package** (Pillow already bundled) — the standard for programmatic PDF generation |
| **svglib** | `>=2.0.2` | LGPL-3.0 | **+4** tiny pure-Python deps (`cssselect2`, `tinycss2`, `webencodings`) — SVG → ReportLab drawings, a clean path from matplotlib SVG output to PDF |

Net: **+5 pure-Python packages**.

## Version bump (kept in sync)

The `executor` and `code-interpreter` packages are released together, so this bumps all of them `0.4.4 → 0.4.5`, matching the release convention from #63:

- `executor/pyproject.toml` + `executor/uv.lock`
- `code-interpreter/pyproject.toml` + `code-interpreter/uv.lock`
- `kubernetes/code-interpreter/Chart.yaml`

## Why these two

- `reportlab` was the explicit ask and is essentially free given Pillow is already present.
- `svglib` complements it (and the existing matplotlib stack) by rendering SVG straight into PDFs, with a negligible footprint.

## What was deliberately skipped

- **xhtml2pdf** (HTML→PDF): resolves to **+20 packages**, including a PDF-signing/crypto stack (`pyHanko`, `oscrypto`, `asn1crypto`, `requests`/`urllib3`), and pins `reportlab<5`. Fails the "lightweight" goal.
- **weasyprint** (HTML/CSS→PDF): requires native system libraries (Pango, cairo, GDK-PixBuf) in the Docker image. Too heavy.
- **borb**: dual-licensed AGPL/commercial — avoided on license grounds.

## Licensing note

`svglib` is **LGPL-3.0**, which matches the existing **`fpdf2`** direct dependency (also LGPL-3.0-only) — so it introduces no new licensing posture. The image only invokes the library (no modification/redistribution of source). No GPL/AGPL anywhere in the dependency tree.

## Verification

- `uv lock --check` passes for both packages (Docker build uses `uv sync --frozen`).
- Smoke-tested in an isolated env: `reportlab` imports and generates a valid PDF; `svglib.svg2rlg` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)