### PR TITLE
Add security scan workflow with auto-fix

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,153 @@
+name: Security Scan & Auto-Fix
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'executor/pyproject.toml'
+      - 'executor/uv.lock'
+      - 'code-interpreter/pyproject.toml'
+      - 'code-interpreter/uv.lock'
+      - 'executor/Dockerfile'
+      - '.github/workflows/security-scan.yml'
+  schedule:
+    # Every Monday at 9am UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    outputs:
+      high_count: ${{ steps.scout.outputs.high_count }}
+      critical_count: ${{ steps.scout.outputs.critical_count }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build executor image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: executor/Dockerfile
+          push: false
+          load: true
+          tags: onyxdotapp/python-executor-sci:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run Docker Scout CVE scan
+        id: scout
+        run: |
+          docker scout cves local://onyxdotapp/python-executor-sci:scan \
+            --format json > scout-report.json || true
+
+          # Extract HIGH/CRITICAL counts
+          HIGH=$(jq '[.[] | select(.severity == "HIGH")] | length' scout-report.json)
+          CRITICAL=$(jq '[.[] | select(.severity == "CRITICAL")] | length' scout-report.json)
+          echo "high_count=$HIGH" >> $GITHUB_OUTPUT
+          echo "critical_count=$CRITICAL" >> $GITHUB_OUTPUT
+
+          # Print summary
+          echo "## Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "- **CRITICAL:** $CRITICAL" >> $GITHUB_STEP_SUMMARY
+          echo "- **HIGH:** $HIGH" >> $GITHUB_STEP_SUMMARY
+      - name: Comment on PR (if HIGH/CRITICAL found)
+        if: steps.scout.outputs.high_count > 0 || steps.scout.outputs.critical_count > 0
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('scout-report.json', 'utf8'));
+
+            const critical = report.filter(v => v.severity === 'CRITICAL').slice(0, 5);
+            const high = report.filter(v => v.severity === 'HIGH').slice(0, 5);
+
+            let comment = '## 🚨 Security Alert\n\n';
+            comment += `**CRITICAL:** ${report.filter(v => v.severity === 'CRITICAL').length} found\n`;
+            comment += `**HIGH:** ${report.filter(v => v.severity === 'HIGH').length} found\n\n`;
+
+            if (critical.length > 0) {
+              comment += '### Critical Issues\n';
+              critical.forEach(v => {
+                comment += `- **${v.id}**: ${v.title} (${v.package})\n`;
+              });
+              comment += '\n';
+            }
+
+            if (high.length > 0) {
+              comment += '### High Issues\n';
+              high.forEach(v => {
+                comment += `- **${v.id}**: ${v.title} (${v.package})\n`;
+              });
+            }
+
+            comment += '\n📋 Full report: [scout-report.json](../../actions/runs/${{ github.run_id }})';
+
+            // Only comment if there's an open PR
+            if (context.issue.number) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            }
+      - name: Fail if CRITICAL found
+        if: steps.scout.outputs.critical_count > 0
+        run: |
+          echo "❌ CRITICAL vulnerabilities detected. Build failed."
+          exit 1
+      - name: Warn if HIGH found
+        if: steps.scout.outputs.high_count > 0
+        run: |
+          echo "⚠️  HIGH vulnerabilities detected. Review and fix before merge."
+      - name: Upload scout report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: scout-cve-report
+          path: scout-report.json
+          retention-days: 30
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    needs: scan
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Enable auto-merge for Dependabot PRs (LOW/MEDIUM only)
+        if: ${{ needs.scan.outputs.high_count == 0 && needs.scan.outputs.critical_count == 0 }}
+        run: |
+          gh pr merge --auto --squash "${{ github.event.pull_request.number }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  schedule-report:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate weekly report
+        run: |
+          echo "# Weekly Security Scan Report" > SECURITY_REPORT.md
+          echo "" >> SECURITY_REPORT.md
+          echo "**Date:** $(date -u +'%Y-%m-%d')" >> SECURITY_REPORT.md
+          echo "**Branch:** ${{ github.ref }}" >> SECURITY_REPORT.md
+      - name: Create issue if vulnerabilities found
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '🔒 Weekly Security Scan - Vulnerabilities Found',
+              body: 'Run security scan to check for new CVEs',
+              labels: ['security', 'automated']
+            });


### PR DESCRIPTION
This workflow performs a security scan on specified files, reports vulnerabilities, and manages Dependabot PRs.

Note: added a job-level `outputs:` block to the `scan` job — without it, `needs.scan.outputs.high_count`/`critical_count` referenced by the downstream jobs are always empty, silently disabling the HIGH/CRITICAL gate on Dependabot auto-merge.