### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Python dependencies via uv.lock
+  - package-ecosystem: "uv"
+    directory: "/executor"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+    allow:
+      - dependency-type: "all"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(executor):"
+  - package-ecosystem: "uv"
+    directory: "/code-interpreter"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+    allow:
+      - dependency-type: "all"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(code-interpreter):"
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci:"


### PR DESCRIPTION
Adds Dependabot version updates for the two uv-managed Python projects plus GitHub Actions.

Two corrections made from the original draft:
- `package-ecosystem` changed from `pip` to `uv` for the `/executor` and `/code-interpreter` entries, since dependencies are tracked via `uv.lock`, not a pip requirements file. Dependabot's `pip` ecosystem won't correctly resolve or update `uv.lock`.
- Removed a `reviewers: ["onyx-dot-app/python-sandbox"]` entry that referenced the repo name rather than a real GitHub team, which would have silently failed to assign a reviewer. Happy to add the correct team/username back in if there is one.