### PR TITLE
Give executor pods an ownerReference to the Deployment

### DIFF
--- a/code-interpreter/app/app_configs.py
+++ b/code-interpreter/app/app_configs.py
@@ -32,6 +32,13 @@ KUBERNETES_EXECUTOR_SERVICE_ACCOUNT = os.environ.get("KUBERNETES_EXECUTOR_SERVIC
 KUBERNETES_EXECUTOR_NET_ADMIN_LOCKDOWN = (
     os.environ.get("KUBERNETES_EXECUTOR_NET_ADMIN_LOCKDOWN") or "true"
 ).lower() not in ("false", "0", "no")
+# Namespace this service runs in, and the name of the Deployment that owns it.
+# When both are set and the service shares a namespace with its executor pods,
+# executor pods get an ownerReference to that Deployment. This lets Kubernetes
+# garbage-collect leaked pods and lets monitoring tell them apart from
+# long-lived workloads. Requires "get" on apps/deployments.
+KUBERNETES_OWN_NAMESPACE = os.environ.get("KUBERNETES_OWN_NAMESPACE") or ""
+KUBERNETES_OWNER_DEPLOYMENT_NAME = os.environ.get("KUBERNETES_OWNER_DEPLOYMENT_NAME") or ""
 
 # Execution limits
 MAX_EXEC_TIMEOUT_MS = int(os.environ.get("MAX_EXEC_TIMEOUT_MS") or 60_000)

--- a/code-interpreter/app/services/executor_kubernetes.py
+++ b/code-interpreter/app/services/executor_kubernetes.py
@@ -16,6 +16,7 @@ from kubernetes import client, config, stream  # type: ignore
 from kubernetes.client import (  # type: ignore[import-untyped]
     V1Container,
     V1ObjectMeta,
+    V1OwnerReference,
     V1Pod,
     V1PodSpec,
 )
@@ -27,6 +28,8 @@ from app.app_configs import (
     KUBERNETES_EXECUTOR_NAMESPACE,
     KUBERNETES_EXECUTOR_NET_ADMIN_LOCKDOWN,
     KUBERNETES_EXECUTOR_SERVICE_ACCOUNT,
+    KUBERNETES_OWN_NAMESPACE,
+    KUBERNETES_OWNER_DEPLOYMENT_NAME,
 )
 from app.services.executor_base import (
     SESSION_APP_LABEL,
@@ -97,6 +100,61 @@ class KubernetesExecutor(BaseExecutor):
         self.image = KUBERNETES_EXECUTOR_IMAGE
         self.service_account = KUBERNETES_EXECUTOR_SERVICE_ACCOUNT
         self.net_admin_lockdown = KUBERNETES_EXECUTOR_NET_ADMIN_LOCKDOWN
+        self.owner_reference = self._resolve_owner_reference()
+
+    def _resolve_owner_reference(self) -> V1OwnerReference | None:
+        """Look up the Deployment that owns this service, to own executor pods.
+
+        Returns None when ownership cannot apply, in which case pods are created
+        without an ownerReference exactly as before. Kubernetes only honours
+        ownerReferences within one namespace: a reference to an owner outside the
+        executor namespace looks like a deleted owner, and garbage collection
+        would delete the executor pod straight away.
+        """
+        if not KUBERNETES_OWNER_DEPLOYMENT_NAME or not KUBERNETES_OWN_NAMESPACE:
+            return None
+
+        if self.namespace != KUBERNETES_OWN_NAMESPACE:
+            logger.info(
+                "Executor pods run in namespace %s but this service runs in %s; "
+                "skipping ownerReferences, which cannot cross namespaces",
+                self.namespace,
+                KUBERNETES_OWN_NAMESPACE,
+            )
+            return None
+
+        try:
+            deployment = client.AppsV1Api(
+                api_client=self._rest_api_client
+            ).read_namespaced_deployment(
+                name=KUBERNETES_OWNER_DEPLOYMENT_NAME,
+                namespace=KUBERNETES_OWN_NAMESPACE,
+            )
+        except Exception as e:
+            # Catch every error, not only ApiException. This runs in __init__,
+            # and __init__ must not raise: /health calls the constructor through
+            # get_executor(), so an unreachable API server here would turn a
+            # graceful health error into a 500 and let the liveness probe
+            # restart the pod. Losing the ownerReference is the lesser cost.
+            logger.warning(
+                "Cannot read Deployment %s in namespace %s (%s); "
+                "executor pods get no ownerReferences",
+                KUBERNETES_OWNER_DEPLOYMENT_NAME,
+                KUBERNETES_OWN_NAMESPACE,
+                e,
+            )
+            return None
+
+        # blockOwnerDeletion stays false: setting it needs "update" on the
+        # owner's finalizers subresource, which this service does not have.
+        return V1OwnerReference(
+            api_version="apps/v1",
+            kind="Deployment",
+            name=deployment.metadata.name,
+            uid=deployment.metadata.uid,
+            controller=True,
+            block_owner_deletion=False,
+        )
 
     def check_health(self) -> HealthCheck:
         """Verify Kubernetes API is reachable and we can create pods in the namespace."""
@@ -245,6 +303,7 @@ class KubernetesExecutor(BaseExecutor):
             namespace=self.namespace,
             labels=dict(labels),
             annotations=dict(annotations) if annotations else None,
+            owner_references=[self.owner_reference] if self.owner_reference else None,
         )
 
         return V1Pod(api_version="v1", kind="Pod", metadata=metadata, spec=spec)

--- a/code-interpreter/pyproject.toml
+++ b/code-interpreter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "code-interpreter"
-version = "0.4.5"
+version = "0.4.6"
 description = "FastAPI service to execute Python code (sync, typed)"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/code-interpreter/tests/integration_tests/test_binary_file_integrity.py
+++ b/code-interpreter/tests/integration_tests/test_binary_file_integrity.py
@@ -26,6 +26,7 @@ def executor() -> KubernetesExecutor:
     inst.image = "test:latest"
     inst.service_account = ""
     inst.net_admin_lockdown = True
+    inst.owner_reference = None
     return inst
 
 

--- a/code-interpreter/tests/integration_tests/test_kubernetes_owner_references.py
+++ b/code-interpreter/tests/integration_tests/test_kubernetes_owner_references.py
@@ -1,0 +1,140 @@
+"""Tests for executor pod ownerReferences.
+
+Unit tests that mock the Kubernetes API to exercise owner resolution
+without requiring a real cluster.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from kubernetes.client import V1OwnerReference  # type: ignore[import-untyped]
+from kubernetes.client.exceptions import ApiException  # type: ignore[import-untyped]
+
+from app.services.executor_kubernetes import KubernetesExecutor
+
+MODULE = "app.services.executor_kubernetes"
+
+
+@pytest.fixture()
+def executor() -> KubernetesExecutor:
+    """Create a KubernetesExecutor bypassing __init__ (no cluster needed)."""
+    inst = KubernetesExecutor.__new__(KubernetesExecutor)
+    inst.v1 = MagicMock()
+    inst._rest_api_client = MagicMock()
+    inst.namespace = "onyx"
+    inst.image = "test:latest"
+    inst.service_account = ""
+    inst.net_admin_lockdown = True
+    inst.owner_reference = None
+    return inst
+
+
+def _deployment(uid: str = "dep-uid-123") -> MagicMock:
+    deployment = MagicMock()
+    deployment.metadata.name = "onyx-code-interpreter"
+    deployment.metadata.uid = uid
+    return deployment
+
+
+def test_owner_reference_resolves_to_deployment(executor: KubernetesExecutor) -> None:
+    apps_api = MagicMock()
+    apps_api.read_namespaced_deployment.return_value = _deployment()
+
+    with (
+        patch(f"{MODULE}.KUBERNETES_OWN_NAMESPACE", "onyx"),
+        patch(f"{MODULE}.KUBERNETES_OWNER_DEPLOYMENT_NAME", "onyx-code-interpreter"),
+        patch(f"{MODULE}.client.AppsV1Api", return_value=apps_api),
+    ):
+        owner = executor._resolve_owner_reference()
+
+    assert owner is not None
+    assert owner.kind == "Deployment"
+    assert owner.api_version == "apps/v1"
+    assert owner.name == "onyx-code-interpreter"
+    assert owner.uid == "dep-uid-123"
+    assert owner.controller is True
+    # Setting this needs "update" on the owner's finalizers, which we lack.
+    assert owner.block_owner_deletion is False
+
+
+def test_owner_reference_is_none_when_unconfigured(executor: KubernetesExecutor) -> None:
+    with (
+        patch(f"{MODULE}.KUBERNETES_OWN_NAMESPACE", ""),
+        patch(f"{MODULE}.KUBERNETES_OWNER_DEPLOYMENT_NAME", ""),
+    ):
+        assert executor._resolve_owner_reference() is None
+
+
+def test_owner_reference_is_none_across_namespaces(executor: KubernetesExecutor) -> None:
+    """A cross-namespace owner reads as deleted, so GC would drop the pod at once."""
+    apps_api = MagicMock()
+    apps_api.read_namespaced_deployment.return_value = _deployment()
+
+    with (
+        patch(f"{MODULE}.KUBERNETES_OWN_NAMESPACE", "onyx"),
+        patch(f"{MODULE}.KUBERNETES_OWNER_DEPLOYMENT_NAME", "onyx-code-interpreter"),
+        patch(f"{MODULE}.client.AppsV1Api", return_value=apps_api),
+    ):
+        executor.namespace = "code-exec"
+        assert executor._resolve_owner_reference() is None
+
+    apps_api.read_namespaced_deployment.assert_not_called()
+
+
+def test_owner_reference_is_none_when_read_forbidden(executor: KubernetesExecutor) -> None:
+    """Without the apps/deployments RBAC rule, pods are created as before."""
+    apps_api = MagicMock()
+    apps_api.read_namespaced_deployment.side_effect = ApiException(status=403, reason="Forbidden")
+
+    with (
+        patch(f"{MODULE}.KUBERNETES_OWN_NAMESPACE", "onyx"),
+        patch(f"{MODULE}.KUBERNETES_OWNER_DEPLOYMENT_NAME", "onyx-code-interpreter"),
+        patch(f"{MODULE}.client.AppsV1Api", return_value=apps_api),
+    ):
+        assert executor._resolve_owner_reference() is None
+
+
+def test_owner_reference_is_none_when_api_unreachable(executor: KubernetesExecutor) -> None:
+    """__init__ must not raise: /health builds the executor via get_executor()."""
+    apps_api = MagicMock()
+    apps_api.read_namespaced_deployment.side_effect = OSError("connection refused")
+
+    with (
+        patch(f"{MODULE}.KUBERNETES_OWN_NAMESPACE", "onyx"),
+        patch(f"{MODULE}.KUBERNETES_OWNER_DEPLOYMENT_NAME", "onyx-code-interpreter"),
+        patch(f"{MODULE}.client.AppsV1Api", return_value=apps_api),
+    ):
+        assert executor._resolve_owner_reference() is None
+
+
+def test_manifest_carries_owner_reference(executor: KubernetesExecutor) -> None:
+    executor.owner_reference = V1OwnerReference(
+        api_version="apps/v1",
+        kind="Deployment",
+        name="onyx-code-interpreter",
+        uid="dep-uid-123",
+        controller=True,
+        block_owner_deletion=False,
+    )
+
+    manifest = executor._create_pod_manifest(
+        pod_name="code-exec-abc",
+        command=["sleep", "3600"],
+        labels={"app": "code-interpreter", "component": "executor"},
+    )
+
+    assert manifest.metadata.owner_references is not None
+    assert len(manifest.metadata.owner_references) == 1
+    assert manifest.metadata.owner_references[0].uid == "dep-uid-123"
+
+
+def test_manifest_omits_owner_reference_when_unresolved(executor: KubernetesExecutor) -> None:
+    manifest = executor._create_pod_manifest(
+        pod_name="code-exec-abc",
+        command=["sleep", "3600"],
+        labels={"app": "code-interpreter", "component": "executor"},
+    )
+
+    assert manifest.metadata.owner_references is None

--- a/code-interpreter/tests/integration_tests/test_kubernetes_streaming.py
+++ b/code-interpreter/tests/integration_tests/test_kubernetes_streaming.py
@@ -33,6 +33,7 @@ def executor() -> KubernetesExecutor:
     inst.image = "test:latest"
     inst.service_account = ""
     inst.net_admin_lockdown = True
+    inst.owner_reference = None
     pod_mock = MagicMock()
     pod_mock.status.phase = "Running"
 

--- a/code-interpreter/tests/integration_tests/test_session_bash_kubernetes.py
+++ b/code-interpreter/tests/integration_tests/test_session_bash_kubernetes.py
@@ -19,6 +19,7 @@ def executor() -> KubernetesExecutor:
     inst.image = "test:latest"
     inst.service_account = ""
     inst.net_admin_lockdown = True
+    inst.owner_reference = None
     return inst
 
 

--- a/code-interpreter/tests/integration_tests/test_sessions_kubernetes.py
+++ b/code-interpreter/tests/integration_tests/test_sessions_kubernetes.py
@@ -33,6 +33,7 @@ def executor() -> KubernetesExecutor:
     inst.image = "test:latest"
     inst.service_account = ""
     inst.net_admin_lockdown = True
+    inst.owner_reference = None
     pod_mock = MagicMock()
     pod_mock.status.phase = "Running"
     inst.v1.read_namespaced_pod.return_value = pod_mock

--- a/code-interpreter/uv.lock
+++ b/code-interpreter/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "code-interpreter"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/kubernetes/code-interpreter/Chart.yaml
+++ b/kubernetes/code-interpreter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: code-interpreter
 description: A Helm chart for Code Interpreter - FastAPI service to execute Python code in isolated environments
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: latest
 keywords:
   - code-execution

--- a/kubernetes/code-interpreter/README.md
+++ b/kubernetes/code-interpreter/README.md
@@ -69,6 +69,7 @@ helm install code-interpreter ./code-interpreter -f my-values.yaml
 | `codeInterpreter.maxExecTimeoutMs` | Maximum execution timeout in milliseconds | `60000` |
 | `codeInterpreter.memoryLimitMb` | Memory limit for code execution in MB | `256` |
 | `codeInterpreter.kubernetesExecutor.image` | Container image used for execution pods | `python-executor-sci` |
+| `codeInterpreter.kubernetesExecutor.setOwnerReferences` | Give execution pods an ownerReference to this chart's Deployment | `true` |
 | `service.type` | Kubernetes service type | `ClusterIP` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `rbac.create` | Create RBAC resources | `true` |
@@ -113,6 +114,24 @@ The chart always uses the Kubernetes executor to run ephemeral pods for code exe
 Required RBAC permissions (automatically created when `rbac.create=true`):
 - Create, get, list, watch, delete pods
 - Create pod exec
+- Get deployments, when `codeInterpreter.kubernetesExecutor.setOwnerReferences=true`
+
+### Owner references
+
+With `codeInterpreter.kubernetesExecutor.setOwnerReferences=true` (the default), each
+execution pod carries an ownerReference to this chart's Deployment. This gives two
+benefits:
+
+- Kubernetes garbage-collects execution pods that the service fails to clean up, for
+  example after an OOM kill.
+- Monitoring can tell short-lived execution pods apart from long-lived workloads,
+  because the standard "pod has an owner" test now applies to them.
+
+The service reads its own Deployment once at startup to build the reference. It skips
+the reference, and logs why, when the read is not permitted or when
+`codeInterpreter.kubernetesExecutor.namespace` names a different namespace than the
+service: Kubernetes does not honour ownerReferences across namespaces, and would treat
+the owner as already deleted.
 
 ## Security Considerations
 

--- a/kubernetes/code-interpreter/templates/deployment.yaml
+++ b/kubernetes/code-interpreter/templates/deployment.yaml
@@ -67,6 +67,16 @@ spec:
             - name: KUBERNETES_EXECUTOR_SERVICE_ACCOUNT
               value: {{ .Values.codeInterpreter.kubernetesExecutor.serviceAccount | quote }}
             {{- end }}
+            {{- if .Values.codeInterpreter.kubernetesExecutor.setOwnerReferences }}
+            # Lets the service own the pods it spawns, so Kubernetes can
+            # garbage-collect them and monitoring can identify them.
+            - name: KUBERNETES_OWN_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBERNETES_OWNER_DEPLOYMENT_NAME
+              value: {{ include "code-interpreter.fullname" . | quote }}
+            {{- end }}
             {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/kubernetes/code-interpreter/templates/role.yaml
+++ b/kubernetes/code-interpreter/templates/role.yaml
@@ -12,6 +12,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create", "get"]
+  {{- if .Values.codeInterpreter.kubernetesExecutor.setOwnerReferences }}
+  # Read this chart's own Deployment to build the executor pod ownerReference.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get"]
+  {{- end }}
   {{- with .Values.rbac.additionalRules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/kubernetes/code-interpreter/values.yaml
+++ b/kubernetes/code-interpreter/values.yaml
@@ -122,6 +122,15 @@ codeInterpreter:
     # (templates/networkpolicy.yaml) becomes the sole network restriction on
     # executor pods, so it must be enforced by the cluster CNI to have effect.
     netAdminLockdown: true
+    # When true, executor and session pods carry an ownerReference to this
+    # chart's Deployment. Kubernetes then garbage-collects pods that the service
+    # leaks (for example after an OOM kill), and monitoring can tell these
+    # short-lived pods apart from long-lived workloads.
+    #
+    # This grants the service "get" on apps/deployments. It has no effect when
+    # kubernetesExecutor.namespace names a different namespace than the service,
+    # because Kubernetes does not honour ownerReferences across namespaces.
+    setOwnerReferences: true
     # Resource limits for execution pods
     podResources:
       limits:


### PR DESCRIPTION
## Summary

Executor and session pods carried no `ownerReferences`. The service creates them
directly through the Kubernetes client rather than through a controller, and
`_create_pod_manifest` never set the field. Two consequences:

- **Monitoring cannot identify them.** The standard "pod has an owner" test that
  distinguishes ephemeral pods from long-lived workloads does not apply, so
  `code-exec-*` pods raise alerts that ephemeral pods should not raise. This was
  reported by a self-hosted deployment whose alerting excludes owned pods.
- **Nothing garbage-collects leaked pods.** One-shot pods run `sleep 3600` with
  `restartPolicy: Never` and no deadline, and cleanup only happens in the
  service's `finally` block. A crash mid-execution leaves the pod for up to an
  hour, then a `Completed` pod until the cluster prunes terminated pods.

This resolves the owning Deployment once at startup and sets it as the owner of
every pod the service creates. Both `code-exec-*` and `code-session-*` pods go
through `_create_pod_manifest`, so both are covered.

## Behavioral changes

- Executor and session pods gain an `ownerReference` to the chart's Deployment
  (`controller: true`, `blockOwnerDeletion: false`).
- The chart grants `get` on `apps/deployments` and passes the service's own
  namespace and Deployment name via the downward API. Both are gated on
  `codeInterpreter.kubernetesExecutor.setOwnerReferences`, default `true`.
- Deleting the Deployment now cascades to in-flight executor pods. This is the
  intended cleanup.

## Design notes

**Why the Deployment, not the service pod.** Owning by the service pod would be
cheaper — the downward API exposes `metadata.uid` with no extra RBAC and no API
call. But a rollout would then garbage-collect live session pods. The Deployment
is stable across rollouts.

**Why the lookup never raises.** It runs in `__init__`, and `/health` builds the
executor through `get_executor()` without a guard. A raising constructor would
turn a graceful health error into a 500 and let the liveness probe restart the
pod, so the lookup catches every exception, not only `ApiException`. It returns
`None` and pods are created exactly as before when the feature is unconfigured,
when the read is not permitted, or when the executor namespace differs from the
service namespace — Kubernetes does not honour `ownerReferences` across
namespaces and would read the owner as deleted, collecting the pod immediately.

**Why `blockOwnerDeletion: false`.** Setting it true requires `update` on the
owner's `finalizers` subresource, which this service does not have and should
not need.

**Known corner case.** The UID is resolved once. Deleting the Deployment with
`--cascade=orphan` and recreating it would leave a stale UID, and new executor
pods would be collected immediately. Normal deletion takes the service pod with
it and forces re-resolution on restart.

## Versions

Bumps `code-interpreter` and the Helm chart 0.4.5 -> 0.4.6, matching the release
convention from #63/#64. `executor/` is unchanged and stays at 0.4.5.

Note that `docker-build-push.yml` triggers on `v*` tags while this repo's
release tags are `code-interpreter-X.Y.Z`, so the image does not build
automatically. The image needs a `workflow_dispatch` run after merge to publish
`:0.4.6` and `:latest`. The chart publishes automatically on merge; if it lands
first, the older image simply ignores the new environment variables.

## Testing

- New `tests/integration_tests/test_kubernetes_owner_references.py`: owner
  resolves correctly; returns `None` when unconfigured, across namespaces (and
  does not call the API), when the read is forbidden, and when the API is
  unreachable; the manifest carries the reference and omits it when unresolved.
- Full suite goes 128 -> 135 passing. The 22 failures are pre-existing on a host
  without a Docker daemon and are identical before and after this change.
- `mypy .`, `ruff check .`, `ruff format --check .` clean. `helm lint` clean, and
  the chart renders correctly with the flag on, off, and with a separate
  executor namespace.
- A server-side dry-run against a live cluster confirms the API accepts this
  `ownerReference` shape. `kubectl auth can-i get deployments.apps` for the
  service account returns `no` today, confirming the new rule is required and
  that the fallback path is reachable during a partial upgrade.

Not yet verified end to end against a live cluster with a built image, which
needs the image published first.

## Follow-ups (not in this PR)

- The Onyx chart pins this subchart at 0.4.3 and needs a separate bump. That
  also pulls in 0.4.4/0.4.5, including the always-on deny-all-egress executor
  NetworkPolicy, so it deserves its own review.
- The Go rewrite in #65 has the same omission at
  `internal/executor/kubernetes.go`.
- The `v*` tag filter in `docker-build-push.yml` does not match the repo's
  actual release tags.