### PR TITLE
Re-pull the executor image when the host removes it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ This is ideal for:
 - CI/CD pipelines
 - Any scenario where you want instant DinD readiness
 
+Note that the pre-loaded executor image lands in the host's image store like any
+other image, so a host-level `docker system prune -a` still removes it. The service
+re-pulls a missing executor image on its own (see
+`PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC`); on air-gapped hosts that
+cannot pull, set that variable to `0` so the watchdog does not retry the registry.
+
 ### Local Deployment
 
 #### Prerequisites

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Configure the service via environment variables:
 - `MAX_OUTPUT_BYTES`: Maximum output size (default: `1048576` = 1MB)
 - `MAX_FILE_SIZE_MB`: Maximum file upload size (default: `10`)
 - `FILE_STORAGE_DIR`: Directory for file storage (default: `/tmp/code-interpreter-files`)
+- `PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC`: How often the Docker backend checks that the executor image is still present on the host and re-pulls it if it was removed, e.g. by `docker system prune -a` (default: `60`; `0` disables, for air-gapped hosts that cannot pull)
 
 ## Security
 

--- a/code-interpreter/app/app_configs.py
+++ b/code-interpreter/app/app_configs.py
@@ -17,6 +17,15 @@ PYTHON_EXECUTOR_DOCKER_RUN_ARGS = os.environ.get("PYTHON_EXECUTOR_DOCKER_RUN_ARG
 # for maximum isolation. Set to a Docker network name (e.g. "onyx_default", "traefik")
 # to allow executor containers to reach services on that network.
 PYTHON_EXECUTOR_DOCKER_NETWORK = os.environ.get("PYTHON_EXECUTOR_DOCKER_NETWORK") or "none"
+# How often (seconds) the image watchdog checks that the executor image is still
+# present on the host and re-pulls it if it has gone missing (e.g. after
+# `docker system prune -a`). Executor containers run with `--pull never`, so without
+# this a removed image breaks every execution until the service is restarted. The
+# common case costs one `docker image inspect` per pass. Set to 0 to disable, e.g.
+# on air-gapped hosts that cannot pull and would only pay a registry timeout.
+PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC = int(
+    os.environ.get("PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC") or 60
+)
 
 # Kubernetes executor configuration
 KUBERNETES_EXECUTOR_NAMESPACE = os.environ.get("KUBERNETES_EXECUTOR_NAMESPACE") or "default"

--- a/code-interpreter/app/main.py
+++ b/code-interpreter/app/main.py
@@ -12,7 +12,14 @@ from typing import Final
 from fastapi import FastAPI
 
 from app.api.routes import router as api_router
-from app.app_configs import EXECUTOR_BACKEND, HOST, PORT, PYTHON_EXECUTOR_DOCKER_IMAGE
+from app.app_configs import (
+    EXECUTOR_BACKEND,
+    HOST,
+    PORT,
+    PYTHON_EXECUTOR_DOCKER_BIN,
+    PYTHON_EXECUTOR_DOCKER_IMAGE,
+    PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC,
+)
 from app.image_ref import normalize_image_ref
 from app.logging_config import setup_logging
 from app.models.schemas import HealthResponse
@@ -28,22 +35,31 @@ logger = logging.getLogger(__name__)
 SERVICE_VERSION: Final[str] = _package_version("code-interpreter")
 
 
-def _ensure_docker_image_available() -> None:
+def _ensure_docker_image_available(*, quiet: bool = False) -> bool:
     """Ensure the Docker executor image is available locally.
 
     This checks if the image exists locally, and if not, attempts to pull it.
-    This runs during application startup to ensure the image is ready before
-    accepting requests.
+    It runs during application startup so the image is ready before accepting
+    requests, and again from the image watchdog so a host that removes the image
+    while the service is running (e.g. ``docker system prune -a``) recovers
+    without a restart.
+
+    Returns ``True`` if the image was missing and had to be pulled. Raises
+    ``RuntimeError`` if the pull fails or times out. With ``quiet``, the routine
+    "image is present" path logs at DEBUG instead of INFO so periodic callers do
+    not fill the log; pulls and failures are always logged.
     """
-    docker_bin = which("docker")
+    present_level = logging.DEBUG if quiet else logging.INFO
+
+    docker_bin = which(PYTHON_EXECUTOR_DOCKER_BIN)
     if not docker_bin:
         logger.warning("Docker binary not found, skipping image check")
-        return
+        return False
 
     image_with_tag = normalize_image_ref(PYTHON_EXECUTOR_DOCKER_IMAGE)
 
     # Check if image exists locally
-    logger.info(f"Checking for Docker image: {image_with_tag}")
+    logger.log(present_level, f"Checking for Docker image: {image_with_tag}")
     check_result = subprocess.run(
         [docker_bin, "image", "inspect", image_with_tag],
         capture_output=True,
@@ -52,8 +68,8 @@ def _ensure_docker_image_available() -> None:
     )
 
     if check_result.returncode == 0:
-        logger.info(f"Docker image {image_with_tag} is already available locally")
-        return
+        logger.log(present_level, f"Docker image {image_with_tag} is already available locally")
+        return False
 
     # Image doesn't exist, try to pull it
     logger.info(f"Docker image {image_with_tag} not found locally, attempting to pull...")
@@ -67,15 +83,16 @@ def _ensure_docker_image_available() -> None:
 
         if pull_result.returncode == 0:
             logger.info(f"Successfully pulled {image_with_tag}")
-        else:
-            error_msg = (
-                pull_result.stderr.decode("utf-8", errors="replace") if pull_result.stderr else ""
-            )
-            logger.error(f"Failed to pull {image_with_tag}: {error_msg}")
-            raise RuntimeError(
-                f"Docker executor image {image_with_tag} is not available locally "
-                f"and could not be pulled. Error: {error_msg}"
-            )
+            return True
+
+        error_msg = (
+            pull_result.stderr.decode("utf-8", errors="replace") if pull_result.stderr else ""
+        )
+        logger.error(f"Failed to pull {image_with_tag}: {error_msg}")
+        raise RuntimeError(
+            f"Docker executor image {image_with_tag} is not available locally "
+            f"and could not be pulled. Error: {error_msg}"
+        )
     except subprocess.TimeoutExpired as e:
         raise RuntimeError(
             f"Timeout while pulling Docker image {image_with_tag}. "
@@ -101,6 +118,41 @@ async def _session_reaper_loop() -> None:
         await _reap_expired_sessions_once()
 
 
+async def _image_watchdog_once() -> None:
+    """Run a single image watchdog pass: re-pull the executor image if it went missing.
+
+    Never raises. A failed re-pull is logged and retried on the next pass; it must
+    not take down a running service that may have live sessions.
+    """
+    try:
+        pulled = await asyncio.to_thread(_ensure_docker_image_available, quiet=True)
+    except Exception:
+        logger.warning(
+            "Executor image watchdog could not restore the executor image; "
+            "will retry on the next pass",
+            exc_info=True,
+        )
+        return
+    if pulled:
+        logger.warning(
+            "Executor image %s was missing from the host (e.g. removed by `docker system prune`) "
+            "and has been re-pulled",
+            normalize_image_ref(PYTHON_EXECUTOR_DOCKER_IMAGE),
+        )
+
+
+async def _image_watchdog_loop(interval_sec: int) -> None:
+    """Periodically make sure the executor image is still present on the host.
+
+    Executor containers start with ``--pull never``, so an image removed by the
+    host (``docker system prune -a``, image garbage collection) would otherwise
+    fail every execution until an operator restarts the service.
+    """
+    while True:
+        await asyncio.sleep(interval_sec)
+        await _image_watchdog_once()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Manage application lifespan events."""
@@ -112,14 +164,29 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Reap any sessions whose TTL elapsed while the service was down.
     await _reap_expired_sessions_once()
-    reaper_task = asyncio.create_task(_session_reaper_loop())
+    background_tasks: list[asyncio.Task[None]] = [asyncio.create_task(_session_reaper_loop())]
+
+    # Keep the executor image present for the lifetime of the service; see
+    # _image_watchdog_loop. Interval 0 disables it (e.g. air-gapped hosts).
+    if EXECUTOR_BACKEND == "docker" and PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC > 0:
+        logger.info(
+            "Starting executor image watchdog (interval: %ds)",
+            PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC,
+        )
+        background_tasks.append(
+            asyncio.create_task(
+                _image_watchdog_loop(PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC)
+            )
+        )
 
     try:
         yield
     finally:
-        reaper_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await reaper_task
+        for task in background_tasks:
+            task.cancel()
+        for task in background_tasks:
+            with suppress(asyncio.CancelledError):
+                await task
 
 
 def create_app() -> FastAPI:

--- a/code-interpreter/app/main.py
+++ b/code-interpreter/app/main.py
@@ -35,44 +35,19 @@ logger = logging.getLogger(__name__)
 SERVICE_VERSION: Final[str] = _package_version("code-interpreter")
 
 
-def _ensure_docker_image_available(*, quiet: bool = False) -> bool:
-    """Ensure the Docker executor image is available locally.
-
-    This checks if the image exists locally, and if not, attempts to pull it.
-    It runs during application startup so the image is ready before accepting
-    requests, and again from the image watchdog so a host that removes the image
-    while the service is running (e.g. ``docker system prune -a``) recovers
-    without a restart.
-
-    Returns ``True`` if the image was missing and had to be pulled. Raises
-    ``RuntimeError`` if the pull fails or times out. With ``quiet``, the routine
-    "image is present" path logs at DEBUG instead of INFO so periodic callers do
-    not fill the log; pulls and failures are always logged.
-    """
-    present_level = logging.DEBUG if quiet else logging.INFO
-
-    docker_bin = which(PYTHON_EXECUTOR_DOCKER_BIN)
-    if not docker_bin:
-        logger.warning("Docker binary not found, skipping image check")
-        return False
-
-    image_with_tag = normalize_image_ref(PYTHON_EXECUTOR_DOCKER_IMAGE)
-
-    # Check if image exists locally
-    logger.log(present_level, f"Checking for Docker image: {image_with_tag}")
-    check_result = subprocess.run(
+def _docker_image_present(docker_bin: str, image_with_tag: str) -> bool:
+    """Return whether ``image_with_tag`` exists in the local image store."""
+    result = subprocess.run(
         [docker_bin, "image", "inspect", image_with_tag],
         capture_output=True,
         timeout=10,
         check=False,
     )
+    return result.returncode == 0
 
-    if check_result.returncode == 0:
-        logger.log(present_level, f"Docker image {image_with_tag} is already available locally")
-        return False
 
-    # Image doesn't exist, try to pull it
-    logger.info(f"Docker image {image_with_tag} not found locally, attempting to pull...")
+def _pull_docker_image(docker_bin: str, image_with_tag: str) -> None:
+    """Pull ``image_with_tag``. Raises ``RuntimeError`` if the pull fails or times out."""
     try:
         pull_result = subprocess.run(
             [docker_bin, "pull", image_with_tag],
@@ -80,24 +55,45 @@ def _ensure_docker_image_available(*, quiet: bool = False) -> bool:
             timeout=300,  # 5 minutes timeout for pulling
             check=False,
         )
-
-        if pull_result.returncode == 0:
-            logger.info(f"Successfully pulled {image_with_tag}")
-            return True
-
-        error_msg = (
-            pull_result.stderr.decode("utf-8", errors="replace") if pull_result.stderr else ""
-        )
-        logger.error(f"Failed to pull {image_with_tag}: {error_msg}")
-        raise RuntimeError(
-            f"Docker executor image {image_with_tag} is not available locally "
-            f"and could not be pulled. Error: {error_msg}"
-        )
     except subprocess.TimeoutExpired as e:
         raise RuntimeError(
             f"Timeout while pulling Docker image {image_with_tag}. "
             "This may indicate network issues or the image is very large."
         ) from e
+
+    if pull_result.returncode == 0:
+        logger.info(f"Successfully pulled {image_with_tag}")
+        return
+
+    error_msg = pull_result.stderr.decode("utf-8", errors="replace") if pull_result.stderr else ""
+    logger.error(f"Failed to pull {image_with_tag}: {error_msg}")
+    raise RuntimeError(
+        f"Docker executor image {image_with_tag} is not available locally "
+        f"and could not be pulled. Error: {error_msg}"
+    )
+
+
+def _ensure_docker_image_available() -> None:
+    """Ensure the Docker executor image is available locally.
+
+    This checks if the image exists locally, and if not, attempts to pull it.
+    This runs during application startup to ensure the image is ready before
+    accepting requests.
+    """
+    docker_bin = which(PYTHON_EXECUTOR_DOCKER_BIN)
+    if not docker_bin:
+        logger.warning("Docker binary not found, skipping image check")
+        return
+
+    image_with_tag = normalize_image_ref(PYTHON_EXECUTOR_DOCKER_IMAGE)
+
+    logger.info(f"Checking for Docker image: {image_with_tag}")
+    if _docker_image_present(docker_bin, image_with_tag):
+        logger.info(f"Docker image {image_with_tag} is already available locally")
+        return
+
+    logger.info(f"Docker image {image_with_tag} not found locally, attempting to pull...")
+    _pull_docker_image(docker_bin, image_with_tag)
 
 
 async def _reap_expired_sessions_once() -> None:
@@ -118,36 +114,48 @@ async def _session_reaper_loop() -> None:
         await _reap_expired_sessions_once()
 
 
-async def _image_watchdog_once() -> None:
-    """Run a single image watchdog pass: re-pull the executor image if it went missing.
+def _restore_docker_image_if_missing() -> None:
+    """Re-pull the executor image if the host has removed it since startup.
 
-    Never raises. A failed re-pull is logged and retried on the next pass; it must
-    not take down a running service that may have live sessions.
+    Executor containers start with ``--pull never``, so an image removed by the
+    host (``docker system prune -a``, image garbage collection) would otherwise
+    fail every execution until an operator restarts the service. The common
+    case, image present, costs one ``docker image inspect`` and logs nothing.
+    """
+    docker_bin = which(PYTHON_EXECUTOR_DOCKER_BIN)
+    if not docker_bin:
+        return  # Startup already warned, and /health reports this case on its own.
+
+    image_with_tag = normalize_image_ref(PYTHON_EXECUTOR_DOCKER_IMAGE)
+    if _docker_image_present(docker_bin, image_with_tag):
+        return
+
+    logger.warning(
+        "Executor image %s is missing from the host (e.g. removed by `docker system prune`); "
+        "re-pulling",
+        image_with_tag,
+    )
+    _pull_docker_image(docker_bin, image_with_tag)
+
+
+async def _image_watchdog_once() -> None:
+    """Run a single image watchdog pass. Never raises.
+
+    A failed re-pull is logged and retried on the next pass; it must not take
+    down a running service that may have live sessions.
     """
     try:
-        pulled = await asyncio.to_thread(_ensure_docker_image_available, quiet=True)
+        await asyncio.to_thread(_restore_docker_image_if_missing)
     except Exception:
         logger.warning(
             "Executor image watchdog could not restore the executor image; "
             "will retry on the next pass",
             exc_info=True,
         )
-        return
-    if pulled:
-        logger.warning(
-            "Executor image %s was missing from the host (e.g. removed by `docker system prune`) "
-            "and has been re-pulled",
-            normalize_image_ref(PYTHON_EXECUTOR_DOCKER_IMAGE),
-        )
 
 
 async def _image_watchdog_loop(interval_sec: int) -> None:
-    """Periodically make sure the executor image is still present on the host.
-
-    Executor containers start with ``--pull never``, so an image removed by the
-    host (``docker system prune -a``, image garbage collection) would otherwise
-    fail every execution until an operator restarts the service.
-    """
+    """Periodically re-pull the executor image if the host removed it."""
     while True:
         await asyncio.sleep(interval_sec)
         await _image_watchdog_once()

--- a/code-interpreter/tests/integration_tests/test_image_watchdog.py
+++ b/code-interpreter/tests/integration_tests/test_image_watchdog.py
@@ -183,7 +183,7 @@ def test_lifespan_starts_watchdog_only_for_docker_backend(
     with (
         patch("app.main.EXECUTOR_BACKEND", backend),
         patch("app.main.PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC", interval_sec),
-        patch("app.main._ensure_docker_image_available", return_value=False),
+        patch("app.main._ensure_docker_image_available"),
         patch("app.main._reap_expired_sessions_once", new=AsyncMock()),
         patch("app.main._image_watchdog_loop", new=_fake_loop),
         TestClient(create_app()),

--- a/code-interpreter/tests/integration_tests/test_image_watchdog.py
+++ b/code-interpreter/tests/integration_tests/test_image_watchdog.py
@@ -1,0 +1,193 @@
+"""Tests for the executor image watchdog.
+
+Executor containers start with ``--pull never``, so if the host removes the
+executor image while the service is running (``docker system prune -a``, image
+garbage collection), every execution fails until the image is back. The
+watchdog re-pulls it from the lifespan so the service recovers on its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.app_configs import PYTHON_EXECUTOR_DOCKER_IMAGE
+from app.image_ref import normalize_image_ref
+from app.main import _image_watchdog_once, create_app
+from app.services.executor_factory import get_executor
+
+IMAGE = normalize_image_ref(PYTHON_EXECUTOR_DOCKER_IMAGE)
+
+
+@pytest.fixture(autouse=True)
+def _clear_executor_cache() -> Generator[None, None, None]:
+    """Reset the lru_cache on get_executor so patches take effect."""
+    get_executor.cache_clear()
+    yield
+    get_executor.cache_clear()
+
+
+def _completed(returncode: int, stderr: bytes = b"") -> subprocess.CompletedProcess[bytes]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=b"", stderr=stderr)
+
+
+class FakeDockerHost:
+    """Stand-in for the docker CLI that tracks which images the host holds.
+
+    Handles the commands the health and watchdog paths issue: ``docker version``,
+    ``docker image inspect`` and ``docker pull``.
+    """
+
+    def __init__(self, *, images: set[str] | None = None, pull_ok: bool = True) -> None:
+        self.images: set[str] = set(images or ())
+        self.pull_ok = pull_ok
+        self.pulls: list[str] = []
+        self.commands: list[list[str]] = []
+
+    def run(self, cmd: list[str], **_: object) -> subprocess.CompletedProcess[bytes]:
+        self.commands.append(list(cmd))
+        args = cmd[1:]  # drop the docker binary
+        if args[:1] == ["version"]:
+            return _completed(0)
+        if args[:2] == ["image", "inspect"]:
+            present = args[2] in self.images
+            return _completed(0 if present else 1, stderr=b"" if present else b"No such image")
+        if args[:1] == ["pull"]:
+            self.pulls.append(args[1])
+            if not self.pull_ok:
+                return _completed(1, stderr=b"manifest unknown")
+            self.images.add(args[1])
+            return _completed(0)
+        raise AssertionError(f"unexpected docker command: {cmd}")
+
+
+@contextmanager
+def _fake_docker(host: FakeDockerHost) -> Iterator[None]:
+    with (
+        patch("app.main.which", return_value="/usr/bin/docker"),
+        patch("app.main.subprocess.run", side_effect=host.run),
+        patch("app.services.executor_docker.subprocess.run", side_effect=host.run),
+    ):
+        yield
+
+
+def test_watchdog_pulls_when_image_missing() -> None:
+    host = FakeDockerHost(images=set())
+
+    with _fake_docker(host):
+        asyncio.run(_image_watchdog_once())
+
+    assert host.pulls == [IMAGE]
+    assert IMAGE in host.images
+
+
+def test_watchdog_does_not_pull_when_image_present() -> None:
+    """The common path must stay cheap: one ``docker image inspect`` and nothing else."""
+    host = FakeDockerHost(images={IMAGE})
+
+    with _fake_docker(host):
+        asyncio.run(_image_watchdog_once())
+
+    assert host.pulls == []
+    assert [cmd[1:3] for cmd in host.commands] == [["image", "inspect"]]
+
+
+def test_watchdog_pulls_pinned_digest_not_moving_tag() -> None:
+    """A digest-pinned deployment must re-pull the pinned digest."""
+    pinned = "onyxdotapp/python-executor-sci@sha256:" + "ab" * 32
+    host = FakeDockerHost(images=set())
+
+    with patch("app.main.PYTHON_EXECUTOR_DOCKER_IMAGE", pinned), _fake_docker(host):
+        asyncio.run(_image_watchdog_once())
+
+    assert host.pulls == [pinned]
+
+
+def test_watchdog_pass_returns_when_pull_fails() -> None:
+    """A failed re-pull is logged and retried later; it must not kill the service."""
+    host = FakeDockerHost(images=set(), pull_ok=False)
+
+    with _fake_docker(host):
+        asyncio.run(_image_watchdog_once())  # must not raise
+
+        assert host.pulls == [IMAGE]
+        assert IMAGE not in host.images
+
+        # The service keeps serving and keeps naming the condition precisely.
+        body = TestClient(create_app()).get("/health").json()
+
+    assert body["status"] == "error"
+    assert f"Executor image {IMAGE} not available locally" == body["message"]
+
+
+@pytest.mark.parametrize("timing_out", ["image", "pull"])
+def test_watchdog_pass_returns_when_docker_times_out(timing_out: str) -> None:
+    def _run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[bytes]:
+        if cmd[1] == timing_out:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+        return _completed(1)
+
+    with (
+        patch("app.main.which", return_value="/usr/bin/docker"),
+        patch("app.main.subprocess.run", side_effect=_run),
+    ):
+        asyncio.run(_image_watchdog_once())  # must not raise
+
+
+def test_health_recovers_after_watchdog_repull() -> None:
+    """The exact reported scenario: a host prune breaks /health, the watchdog restores it."""
+    host = FakeDockerHost(images={IMAGE})
+
+    with _fake_docker(host):
+        client = TestClient(create_app())
+        assert client.get("/health").json()["status"] == "ok"
+
+        # The host removes the dormant image while the service is running.
+        host.images.clear()
+        body = client.get("/health").json()
+        assert body["status"] == "error"
+        assert "not available locally" in body["message"]
+
+        asyncio.run(_image_watchdog_once())
+
+        assert host.pulls == [IMAGE]
+        body = client.get("/health").json()
+
+    assert body["status"] == "ok"
+    assert body["message"] is None
+
+
+@pytest.mark.parametrize(
+    ("backend", "interval_sec", "expected_intervals"),
+    [
+        ("docker", 45, [45]),
+        ("docker", 0, []),  # interval 0 disables the watchdog (air-gapped hosts)
+        ("kubernetes", 45, []),  # the watchdog is Docker-specific
+    ],
+)
+def test_lifespan_starts_watchdog_only_for_docker_backend(
+    backend: str, interval_sec: int, expected_intervals: list[int]
+) -> None:
+    started: list[int] = []
+
+    async def _fake_loop(interval_sec: int) -> None:
+        started.append(interval_sec)
+        await asyncio.Event().wait()  # park until the lifespan cancels us
+
+    with (
+        patch("app.main.EXECUTOR_BACKEND", backend),
+        patch("app.main.PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC", interval_sec),
+        patch("app.main._ensure_docker_image_available", return_value=False),
+        patch("app.main._reap_expired_sessions_once", new=AsyncMock()),
+        patch("app.main._image_watchdog_loop", new=_fake_loop),
+        TestClient(create_app()),
+    ):
+        pass
+
+    assert started == expected_intervals


### PR DESCRIPTION
## Summary

The service pulls the executor image once at startup and never again. Every container start uses `--pull never`, so if the host removes the image while the service runs (`docker system prune -a`, `docker image prune -a`, host-level image GC), every execution fails until an operator restarts the container. `/health` already reports the exact condition (`Executor image ... not available locally`), but nothing acts on it, and Compose's `restart: unless-stopped` only reacts to the process exiting. This is the mechanism behind onyx-dot-app/onyx#10142.

This PR adds an **image watchdog** to the lifespan, beside the existing session reaper:

- Periodically checks that the executor image is present and, when it is missing, re-runs the same pull routine startup uses. It goes through `normalize_image_ref`, so a digest-pinned deployment re-pulls the pinned digest rather than a moving tag.
- A failed re-pull is logged as a warning and retried on the next pass. It never raises, so it cannot take down a running service with live sessions.
- Execution keeps `--pull never`, so an absent image still fails fast rather than blocking on a registry, and only the image vetted by the pull ever runs.
- `/health` is untouched and stays side-effect free (Onyx polls it with a 5s timeout). The health message is unchanged.
- The common case ("image is present") costs one `docker image inspect` per pass and logs nothing. A missing image logs one WARNING naming the image before the re-pull.
- The startup pull routine is split into `_docker_image_present` and `_pull_docker_image` helpers; startup and the watchdog compose them, so the single pull path is shared without a logging flag.

Recovery now takes at most one watchdog interval instead of an operator.

### Configuration

`PYTHON_EXECUTOR_DOCKER_IMAGE_WATCHDOG_INTERVAL_SEC` (default `60`). Set to `0` to disable, e.g. on air-gapped hosts that cannot pull and would only pay a registry timeout on each pass. The watchdog only starts for the Docker backend. Documented in the README configuration list and in CONTRIBUTING next to the pre-loaded image section (a pre-loaded image lands in the host image store like any other and is removed by a prune the same way).

### Also in this PR

The startup image check resolved the binary with `which("docker")` while the executor honors `PYTHON_EXECUTOR_DOCKER_BIN`. With a custom binary path the watchdog would have logged a false "Docker binary not found" warning every pass, so the check now uses the same setting as the executor.

## Test plan

New integration tests in `tests/integration_tests/test_image_watchdog.py`, following the `test_health.py` style of patching `subprocess.run`, using a small fake Docker host that tracks which images exist:

- [x] Missing image triggers exactly one `docker pull`
- [x] Present image costs one `docker image inspect` and nothing else (no pull)
- [x] Digest-pinned reference is re-pulled as the pinned digest
- [x] Failed pull returns without raising; `/health` keeps serving and still names the condition
- [x] Timed-out `image inspect` and timed-out `pull` both return without raising
- [x] Recovery is observable: `/health` ok → image removed → `/health` error → one watchdog pass → `/health` ok
- [x] Lifespan starts the watchdog only for the Docker backend with a positive interval; `0` disables it
- [x] `mypy .` (strict), `ruff check .`, `ruff format --check .` pass
- [ ] Manual check on a real Docker host (not possible in my environment): start the service, confirm execution works, `docker rmi` the executor image, confirm `/health` turns `error`, wait one interval, confirm `/health` returns `ok` and execution works again

Fixes onyx-dot-app/onyx#10142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
